### PR TITLE
Fix parallel builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 all: elf
 
 elf: elf.asm
-	nasm elf.asm -f bin -o elf
+	nasm elf.asm -f bin -o elf && \
 	chmod +x elf


### PR DESCRIPTION
With this minor change it's guaranteed that make will always runs `chmod` AFTER `nasm` even when running parallel builds.